### PR TITLE
Added protection to unknowned method on iOS7

### DIFF
--- a/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
+++ b/Pod/Classes/ios/NYTPhotoDismissalInteractionController.m
@@ -150,7 +150,13 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
             .patchVersion = 0
         };
 
-        isRadar20070670Fixed = [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:iOSVersion8Point3];
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        if ([processInfo respondsToSelector:@selector(isOperatingSystemAtLeastVersion:)]) {
+            isRadar20070670Fixed = [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:iOSVersion8Point3];
+        }
+        else {
+            isRadar20070670Fixed = NO;
+        }
     });
 
     return isRadar20070670Fixed;

--- a/Pod/Classes/ios/NYTPhotosViewController.m
+++ b/Pod/Classes/ios/NYTPhotosViewController.m
@@ -185,8 +185,19 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     self.transitioningDelegate = _transitionController;
     self.modalPresentationCapturesStatusBarAppearance = YES;
 
+    UIImage *image;
+    UIImage *landscapeImage;
+    if ([UIImage resolveInstanceMethod:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
+        image = [UIImage imageNamed:@"NYTPhotoViewerCloseButtonX" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil];
+        landscapeImage = [UIImage imageNamed:@"NYTPhotoViewerCloseButtonXLandscape" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil];
+    }
+    else {
+        image = [UIImage imageNamed:@"NYTPhotoViewerCloseButtonX"];
+        landscapeImage = [UIImage imageNamed:@"NYTPhotoViewerCloseButtonXLandscape"];
+    }
+
     _overlayView = [[NYTPhotosOverlayView alloc] initWithFrame:CGRectZero];
-    _overlayView.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"NYTPhotoViewerCloseButtonX" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil] landscapeImagePhone:[UIImage imageNamed:@"NYTPhotoViewerCloseButtonXLandscape" inBundle:[NSBundle nyt_photoViewerResourceBundle] compatibleWithTraitCollection:nil] style:UIBarButtonItemStylePlain target:self action:@selector(doneButtonTapped:)];
+    _overlayView.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image landscapeImagePhone:landscapeImage style:UIBarButtonItemStylePlain target:self action:@selector(doneButtonTapped:)];
     _overlayView.leftBarButtonItem.imageInsets = NYTPhotosViewControllerCloseButtonImageInsets;
     _overlayView.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionButtonTapped:)];
 


### PR DESCRIPTION
- The first one is a protection for a known bug, if `NSProcessInfo` doesn't respond to the selector that means we are using an OS lower than iOS8 so the bug isn't fix.
- The second one, iOS7 doesn't know about `UITraitCollection`